### PR TITLE
Draft ActivitySource Child Activity PropagationData solution

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -25,13 +25,12 @@
     <Compile Include="System\Diagnostics\DiagnosticSource.cs" />
     <Compile Include="System\Diagnostics\DiagnosticListener.cs" />
     <Compile Include="System\Diagnostics\DiagnosticSourceEventSource.cs" />
-    <Compile Include="$(CommonPath)System\Runtime\CompilerServices\PreserveDependencyAttribute.cs"
-             Link="Common\System\Runtime\CompilerServices\PreserveDependencyAttribute.cs" />
+    <Compile Include="$(CommonPath)System\Runtime\CompilerServices\PreserveDependencyAttribute.cs" Link="Common\System\Runtime\CompilerServices\PreserveDependencyAttribute.cs" />
+    <Compile Include="System\Diagnostics\ParentActivityState.cs" />
     <None Include="DiagnosticSourceUsersGuide.md" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.1'">
-    <Compile Include="$(CommonPath)System\HexConverter.cs"
-             Link="Common\System\HexConverter.cs" />
+    <Compile Include="$(CommonPath)System\HexConverter.cs" Link="Common\System\HexConverter.cs" />
     <Compile Include="System\Diagnostics\Activity.cs" />
     <Compile Include="System\Diagnostics\ActivityContext.cs" />
     <Compile Include="System\Diagnostics\ActivityCreationOptions.cs" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityListener.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityListener.cs
@@ -46,7 +46,7 @@ namespace System.Diagnostics
         /// <summary>
         /// Set or get the callback used to decide allowing creating <see cref="Activity"/> objects with specific data state.
         /// </summary>
-        public GetRequestedData<ActivityContext>? GetRequestedDataUsingContext { get; set; }
+        public GetRequestedData<ParentActivityState>? GetRequestedDataUsingContext { get; set; }
 
         /// <summary>
         /// Dispose will unregister this <see cref="ActivityListener"/> object from listeneing to <see cref="Activity"/> events.

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ParentActivityState.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ParentActivityState.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics
+{
+    public readonly struct ParentActivityState : IEquatable<ParentActivityState>
+    {
+        public ParentActivityState(ActivityDataRequest requestedData, ActivityContext activityContext)
+        {
+            RequestedData = requestedData;
+            ActivityContext = activityContext;
+        }
+
+        public ActivityDataRequest RequestedData { get; }
+
+        public ActivityContext ActivityContext { get; }
+
+        public bool Equals(ParentActivityState other) => ActivityContext.Equals(other.ActivityContext) && RequestedData == other.RequestedData;
+
+        public override int GetHashCode() => HashCode.Combine(RequestedData, ActivityContext);
+
+        public override bool Equals(object? obj) => (obj is ParentActivityState context) && Equals(context);
+        public static bool operator ==(ParentActivityState left, ParentActivityState right) => left.Equals(right);
+        public static bool operator !=(ParentActivityState left, ParentActivityState right) => !(left == right);
+    }
+}


### PR DESCRIPTION
/cc @cijothomas @tarekgh

Here's a scratch solution for the issue we discussed earlier today wrt `ActivityDataRequest.PropagationData` being hard to determine when child Activity is created/sampled.

What I tried to do was reconstruct the `ActivityDataRequest` used by the Parent so that it can be passed into the "sampler" logic when a child is created.

Let me know what you guys think. I didn't want to go too far with it before testing the water.

The logic is basically...

* If no ActivityContext (default), ActivityDataRequest.None.
* If ActivityTraceFlags.Recorded, ActivityDataRequest.AllDataAndRecorded.
* If there is an Activity.Current and it is IsAllDataRequested, ActivityDataRequest.AllData.
* Otherwise ActivityDataRequest.PropagationData.

When this is all happening in proc, there is enough data to do it. When that state is transmitted over the wire it's going to be hard to restore all the states. In that case you know you have a context and it is or isn't Recorded. If Recorded, you are ActivityDataRequest.AllDataAndRecorded. If not recorded you could be either ActivityDataRequest.PropagationData or ActivityDataRequest.AllData. I don't think we can solve that without expanding W3C ActivityTraceFlags. Or we could also just drop ActivityDataRequest.AllData? I don't really see the value it is adding to the mix.